### PR TITLE
fix to make it work in linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@
 
 EXEC = clinfo
 
-CFLAGS = -Wall -O3
+CFLAGS = -Wall -O3 -std=c99
 LDFLAGS =
 
 ifeq ($(shell uname),Darwin)
 	LDFLAGS += -framework OpenCL
 else
-	LDFLAGS += -lopencl
+	LDFLAGS += -lOpenCL -lm
 endif
 
 prefix = /usr/local


### PR DESCRIPTION
Hey, nice job!
a small fix, the lib is always named OpenCL in linux and gcc needs -lm and -std=c99